### PR TITLE
Changed the way the configuration data is passed to the converter

### DIFF
--- a/application/src/main/java/cloud/benchflow/driversmaker/resources/FabanConfigResource.java
+++ b/application/src/main/java/cloud/benchflow/driversmaker/resources/FabanConfigResource.java
@@ -1,5 +1,6 @@
 package cloud.benchflow.driversmaker.resources;
 
+import com.google.common.io.ByteStreams;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
@@ -10,6 +11,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -30,9 +32,12 @@ public class FabanConfigResource {
     public String convert(@FormDataParam("benchflow-config")
                           InputStream benchflowConfig,
                           @FormDataParam("benchflow-config")
-                          FormDataContentDisposition benchflowConfigDetail) {
+                          FormDataContentDisposition benchflowConfigDetail) throws IOException {
         //returns benchflow config converted to faban xml
-        return bfc.from(benchflowConfig);
+        byte[] data = ByteStreams.toByteArray(benchflowConfig);
+        String yamlConfig = new String(data);
+        return bfc.fromString(yamlConfig);
+//        return bfc.from(benchflowConfig);
     }
 
 }

--- a/application/src/main/scala/cloud/benchflow/config/converter/BenchflowConfigConverter.scala
+++ b/application/src/main/scala/cloud/benchflow/config/converter/BenchflowConfigConverter.scala
@@ -114,10 +114,22 @@ class BenchFlowConfigConverter(val javaHome: String, val javaOpts: String) {
     FabanXML(toXML(map).head, javaHome, javaOpts)
   }
 
+  private def convertFromString(in: String): Elem = {
+    import XMLGenerator._
+    val map = (new Yaml load in).asInstanceOf[java.util.Map[String, Any]]
+    FabanXML(toXML(map).head, javaHome, javaOpts)
+  }
+
   def from(in: InputStream): String = {
     val sb = new StringBuilder()
     sb ++= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + Properties.lineSeparator
     (sb ++= new PrettyPrinter(60, 2).format(convert(in))).toString
+  }
+
+  def fromString(in : String): String = {
+    val sb = new StringBuilder()
+    sb ++= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + Properties.lineSeparator
+    (sb ++= new PrettyPrinter(60, 2).format(convertFromString(in))).toString
   }
 
 }

--- a/application/src/test/resources/camundaTest.yml
+++ b/application/src/test/resources/camundaTest.yml
@@ -35,4 +35,4 @@ benchFlowBenchmark:
           statsStart: http://195.176.181.105:9302/start
           statsStop: http://195.176.181.105:9302/stop
     - runInfo:
-        runID: camunda
+        runID: sut_camunda_1M

--- a/application/src/test/resources/camundaTest.yml
+++ b/application/src/test/resources/camundaTest.yml
@@ -21,6 +21,7 @@ benchFlowBenchmark:
         agents: 195.176.181.45:5 195.176.181.55:10 195.176.181.106:10
         stats:
           interval: 30
+
   sut:
     - sutConfig:
         hostPorts: 195.176.181.105:8080
@@ -29,7 +30,9 @@ benchFlowBenchmark:
         name: camunda
     - services:
         benchFlowCompose: http://195.176.181.55:8090
-        monitors:
         collectors:
+          mysqldumpData: http://10.40.1.128:9301/data
+          statsStart: http://195.176.181.105:9302/start
+          statsStop: http://195.176.181.105:9302/stop
     - runInfo:
         runID: camunda

--- a/configuration.yml
+++ b/configuration.yml
@@ -6,11 +6,11 @@ server:
   type: default
   applicationConnectors:
     - type: http
-      port: 6060
+      port: 8080
 #      bindHost: 127.0.0.1 # only bind to loopback
   adminConnectors:
     - type: http
-      port: 6061
+      port: 8081
 #      bindHost: 127.0.0.1 # only bind to loopback
 
 logging:

--- a/configuration.yml
+++ b/configuration.yml
@@ -6,11 +6,11 @@ server:
   type: default
   applicationConnectors:
     - type: http
-      port: 8080
+      port: 6060
 #      bindHost: 127.0.0.1 # only bind to loopback
   adminConnectors:
     - type: http
-      port: 8081
+      port: 6061
 #      bindHost: 127.0.0.1 # only bind to loopback
 
 logging:


### PR DESCRIPTION
Passing the inputStream directly would cause an exception because for
some reason the stream would already be closed by the time the
conversion started. Solved the problem by reading the stream into a
string, and converting that string.